### PR TITLE
Use contactsHeading for site-footer-widget-title

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -125,7 +125,7 @@
           </div>
           <div class="col-lg-3 col-md-6">
             <div class="site-footer-widget">
-              <h5 class="site-footer-widget-title">Contact Info</h5>
+              <h5 class="site-footer-widget-title">{{footer.contactsHeading}}</h5>
               <p class="site-footer-widget-description">
               {% for contactInfo in footer.contactsInfo %}
                 <a href="{{contactInfo.link}}">{{contactInfo.text}}</a>


### PR DESCRIPTION
Use `contactsHeading` in the footer.json for the site-footer-widget-title

Hi, I'm Yuki.
I found that the `contactsHeading` is not used anywhere.
It seems that it should be used for `site-footer-widget-title`.
Thank you for creating such a great template.